### PR TITLE
Add convenience methods and fix example in readme.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,23 +29,27 @@ or just let you run into a timout.
 Do all checks at once:
 
 ```go
-result, err := mailck.Check("noreply@mancke.net", "foo@example.com")
+result, _ := mailck.Check("noreply@mancke.net", "foo@example.com")
+switch {
 
-switch result.Result {
+  case result.IsValid():
+  // valid!
+  // the mailserver accepts mails for this mailbox.
 
-  case mailck.Valid:
-    // valid!
-    // the mailserver accepts mails for this mailbox.
-
-  case mailck.Invalid:
-    // invalid, e.g. bacause
-    // the reason is contained in result.ResultDetail
-
-  case mailck.Error:
+  case result.IsError():
   // something went wrong in the smtp communication
   // we can't say for sure if the address is valid or not
 
-
+  case result.IsInvalid():
+  // invalid for some reason
+  // the reason is contained in result.ResultDetail
+  // or we can check for different reasons:
+  switch (result) {
+    case mailck.InvalidDomain:
+    // domain is invalid
+    case mailck.InvalidSyntax:
+    // e-mail address syntax is invalid
+  }
 }
 ```
 

--- a/result.go
+++ b/result.go
@@ -17,3 +17,15 @@ var (
 	ServiceError       = Result{"error", "serviceError", "An internal error occured while checking."}
 	clientError        = Result{"error", "clientError", "The request was was invalid."}
 )
+
+func (r Result) IsValid() bool {
+	return r.Result == "valid"
+}
+
+func (r Result) IsInvalid() bool {
+	return r.Result == "invalid"
+}
+
+func (r Result) IsError() bool {
+	return r.Result == "error"
+}


### PR DESCRIPTION
Added some convenience methods to check the broad classification of the result (valid/invalid/error). The example in readme.MD was also not working so updated that to reflect the same concept with the new API. If you don't want to add the methods, will be happy to provide a PR with just a fixed example.